### PR TITLE
close #1: update js RegExp match range property

### DIFF
--- a/lib/hide-lines.coffee
+++ b/lib/hide-lines.coffee
@@ -30,7 +30,7 @@ module.exports =
 
     for pattern in patterns
       editor.scan new RegExp(pattern, 'g'), (m) ->
-        row = m.computedRange.end.row
+        row = m.range.end.row
 
         if rowsToHide.indexOf(row) == -1
           rowsToHide.push(row)


### PR DESCRIPTION
Not sure where `computedRange` in `m.computedRange.end.row` came from  -- is this old Atom API?

Simply replacing with `range` closes #1.